### PR TITLE
Removed `-ju` argument for benchmark.sh

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -216,10 +216,6 @@ args_cases="--cases=$CASES --log2p=$LOG2P --max_steps=$MAXSTEPS --ftype=$FTYPE"
 # Benchmarks
 for version in "${VERSIONS[@]}" ; do
     echo "Running with Julia version $version from $( which julia )"
-    # if [[ check_if_juliaup && DEFAULT_VERSION -eq 1 ]]; then
-    #     printf "ALIASING JULIA NOW!"
-    #     alias julia="julia +$version"
-    # fi
     for wl_version in "${WL_VERSIONS[@]}" ; do
         update_environment
         for backend in "${BACKENDS[@]}" ; do

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -178,10 +178,10 @@ else
     WL_VERSIONS=($(waterlily_version))
 fi
 
-# Check if Julia versions have been specified, and if so that juliaup is installed
+# Check if Julia versions have been specified, and if so check that juliaup is installed
 if (( ${#VERSIONS[@]} != 0 )); then
     if ! check_if_juliaup; then
-        printf "Versions ${WL_VERSIONS[@]} where requested, but juliaup is not found."
+        printf "Versions ${WL_VERSIONS[@]} were requested, but juliaup is not found."
     fi
 else
     VERSIONS=($JULIA_USER_VERSION)

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -18,6 +18,7 @@ join_array_tuple_comma () {
     printf -v joined '(%s),' $arr
     echo "[${joined%,}]"
 }
+
 # Check if juliaup exists in environment
 check_if_juliaup () {
     if command -v juliaup &> /dev/null
@@ -27,15 +28,26 @@ check_if_juliaup () {
         return 1
     fi
 }
+
 # Grep current julia version
 julia_version () {
     julia_v=($(julia -v))
     echo "${julia_v[2]}"
 }
+
 # Get current WaterLily version
 waterlily_version () {
     waterlily_v=($(git -C $WATERLILY_DIR rev-parse --short HEAD))
     echo "${waterlily_v}"
+}
+
+# Julia command based on juliaup or not
+julia_cmd () {
+    if [[ check_if_juliaup && DEFAULT_VERSION -eq 1 ]]; then
+        julia +$version "${full_args[@]}"
+    else
+        julia "${full_args[@]}"
+    fi
 }
 
 # Update project environment with new Julia version: Mark WaterLily as a development packag, then update dependencies and precompile.
@@ -47,13 +59,14 @@ update_environment () {
         cd $THIS_DIR
     fi
     echo "Updating environment to Julia $version and compiling WaterLily"
-    julia --project=$THIS_DIR -e "using Pkg; Pkg.develop(PackageSpec(path=get(ENV, \"WATERLILY_DIR\", \"\"))); Pkg.update();"
+    full_args=(--project=$THIS_DIR -e "using Pkg; Pkg.develop(PackageSpec(path=get(ENV, \"WATERLILY_DIR\", \"\"))); Pkg.update();")
+    julia_cmd
 }
 
 run_benchmark () {
     full_args=(--project=${THIS_DIR} --startup-file=no $args)
     echo "Running: julia ${full_args[@]}"
-    julia "${full_args[@]}"
+    julia_cmd
 }
 
 # Print benchamrks info
@@ -77,6 +90,7 @@ display_info () {
 # Default backends
 JULIA_USER_VERSION=$(julia_version)
 VERSIONS=()
+DEFAULT_VERSION=0
 WL_DIR=""
 WL_VERSIONS=()
 BACKENDS=('Array' 'CuArray')
@@ -182,7 +196,9 @@ fi
 if (( ${#VERSIONS[@]} != 0 )); then
     if ! check_if_juliaup; then
         printf "Versions ${WL_VERSIONS[@]} were requested, but juliaup is not found."
+        exit 1
     fi
+    DEFAULT_VERSION=1
 else
     VERSIONS=($JULIA_USER_VERSION)
 fi
@@ -200,9 +216,10 @@ args_cases="--cases=$CASES --log2p=$LOG2P --max_steps=$MAXSTEPS --ftype=$FTYPE"
 # Benchmarks
 for version in "${VERSIONS[@]}" ; do
     echo "Running with Julia version $version from $( which julia )"
-    if check_if_juliaup; then
-        alias julia="julia +$version"
-    fi
+    # if [[ check_if_juliaup && DEFAULT_VERSION -eq 1 ]]; then
+    #     printf "ALIASING JULIA NOW!"
+    #     alias julia="julia +$version"
+    # fi
     for wl_version in "${WL_VERSIONS[@]}" ; do
         update_environment
         for backend in "${BACKENDS[@]}" ; do


### PR DESCRIPTION
Now the julia +version syntax from juliaup will only be used if `--versions` is passed. Otherwise, it defaults to the system Julia version (this being the current juliaup channel of the system-wide julia).