### PR TITLE
Rename initial-condition keyword `uλ` → `u0`

### DIFF
--- a/cases.jl
+++ b/cases.jl
@@ -3,13 +3,13 @@ using StaticArrays
 
 function tgv(p, backend; Re=1600, T=Float32)
     L = 2^p; U = T(1); κ=T(π/L); ν = T(1/(κ*Re))
-    function uλ(i,xyz)
+    function u0(i,xyz)
         x,y,z = @. xyz*κ
         i==1 && return -U*sin(x)*cos(y)*cos(z)
         i==2 && return  U*cos(x)*sin(y)*cos(z)
         return 0*U
     end
-    Simulation((L, L, L), (0, 0, 0), 1/κ; U, uλ, ν, T, mem=backend)
+    Simulation((L, L, L), (0, 0, 0), 1/κ; U, u0, ν, T, mem=backend)
 end
 
 function sphere(p, backend; Re=3700, U=1, T=Float32)


### PR DESCRIPTION
Adapt to the new WaterLily initial condition keyword change https://github.com/WaterLily-jl/WaterLily.jl/pull/303. Note that users receive a deprecation warning when still using `uλ` instead of `u0`. The full deprecation is planned for WaterLily 2.0.