### PR TITLE
Reduce GPU cold-start noise; surface measurement noise in compare table

### DIFF
--- a/compare.jl
+++ b/compare.jl
@@ -68,8 +68,8 @@ for (i, case) in enumerate(cases)
     log2p_str = sort(log2p_str[1])
     f_test = benchmarks[1].tags[2]
     # Get data for PrettyTables
-    header_top    = ["Backend", "WaterLily", "Julia", "FP", "Alloc", "GC",  "Min", "Med", "Max", "Cost",        "Δ",   "Speedup"]
-    header_units  = [""       , ""         , ""     , ""  , "[k]"  , "[%]", "[s]", "[s]", "[s]", "[ns/DOF/dt]", "[%]", ""       ]
+    header_top    = ["Backend", "WaterLily", "Julia", "FP", "Alloc", "GC",  "Min", "Med", "Max", "Cost",        "Δ",   "Speedup", "Noise"]
+    header_units  = [""       , ""         , ""     , ""  , "[k]"  , "[%]", "[s]", "[s]", "[s]", "[ns/DOF/dt]", "[%]", ""       , "[%]"  ]
     column_labels = [header_top, header_units]
     data = Matrix{Any}(undef, length(benchmarks), length(header_top))
     plotting_data = zeros(length(log2p_str), length(unique(backends_str)), 3) # times, cost, speedups
@@ -80,6 +80,7 @@ for (i, case) in enumerate(cases)
         for (i, benchmark) in enumerate(benchmarks)
             datap = benchmark[backends_str[i]][n][f_test]
             tmin = minimum(datap.times)
+            noise_pct = (maximum(datap.times) - tmin) / tmin * 100 # within-run spread; |Δ| below this ≈ noise
             if !isnothing(speedup_base)
                 speedup = minimum(benchmarks[speedup_base_idx][speedup_base_backend][n][f_test].times) / tmin
             else
@@ -91,7 +92,7 @@ for (i, case) in enumerate(cases)
             gc_pct = datap.gctimes[imin] / datap.times[imin] * 100.0
             waterlily_ref = String(find_git_ref(benchmark.tags[end-1]))
             data[i, :] .= [backends_str[i], waterlily_ref, benchmark.tags[end], benchmark.tags[end-3],
-                datap.allocs / 1000, gc_pct, tmin / 1e9, median(datap.times) / 1e9, maximum(datap.times) / 1e9, cost, 0.0, speedup]
+                datap.allocs / 1000, gc_pct, tmin / 1e9, median(datap.times) / 1e9, maximum(datap.times) / 1e9, cost, 0.0, speedup, noise_pct]
             versions_key = (waterlily_ref, benchmark.tags[end], benchmark.tags[end-3])
             backend_idx = findall(x -> x == backends_str[i], unique(backends_str))[1]
             plotting_data[k, backend_idx, :] .= (data[i, 7], data[i, 10], data[i, 12])
@@ -143,10 +144,14 @@ for (i, case) in enumerate(cases)
         pct2_cols = [ocol_to_dcol[c] for c in [6,7,8,9,10,12] if haskey(ocol_to_dcol, c)]
         delta_col = ocol_to_dcol[11]
         alloc_col = ocol_to_dcol[5]
+        noise_col = ocol_to_dcol[13]
         fmt_delta_dash = (v, i, j) -> (j == delta_col && v isa Number && isnan(v)) ? "-" : v
         pretty_table(disp_data; backend=:text, column_labels=disp_labels, column_label_alignment=:c,
             highlighters=[hl_base, hl_per_backend...],
-            formatters = [fmt_delta_dash, fmt__printf("%.2f", pct2_cols), fmt__printf("%+.1f", [delta_col]), fmt__printf("%.1f", [alloc_col])])
+            formatters = [fmt_delta_dash, fmt__printf("%.2f", pct2_cols), fmt__printf("%+.1f", [delta_col]),
+                          fmt__printf("%.1f", [alloc_col]), fmt__printf("%.1f", [noise_col])])
+        # Treat |Δ| below `Noise` (min→max sample spread) as scatter, not a real change. `Alloc` is only
+        # meaningful on SIMD (CPUx01); KA backends (multi-thread CPU, GPU) report kernel-launch bookkeeping.
     end
 
     # Plotting each configuration of WaterLily version, Julia version and precision in benchamarks

--- a/util.jl
+++ b/util.jl
@@ -30,13 +30,28 @@ macro add_benchmark(args...)
     end |> esc
 end
 
+# Warm up until BOTH a step count and a wall-clock budget are met, so small fast cases
+# drive the device to steady (boost) clocks before timing. A short fixed-step warm-up
+# leaves a freshly precompiled GPU at idle clocks, giving the first version in a session a
+# cold-start penalty (the spurious ~3x GPU swings in the v7-v8 data). `min_steps` dominates
+# for large cases, so only the clock-sensitive small ones pay extra.
+function warmup!(sim, ft, remeasure, KA_backend; min_steps=50, seconds=2.0)
+    steps = 0; t0 = time()
+    while steps < min_steps || (time() - t0) < seconds
+        sim_step!(sim, typemax(ft); max_steps=10, verbose=false, remeasure=remeasure)
+        KernelAbstractions.synchronize(KA_backend)
+        steps += 10
+    end
+    return steps
+end
+
 function add_to_suite!(suite, sim_function; p=(3,4,5), s=100, ft=Float32, backend=Array, bstr="CPU", remeasure=false)
     suite[bstr] = BenchmarkGroup([bstr])
     for n in p
         sim = sim_function(n, backend; T=ft)
-        sim_step!(sim, typemax(ft); max_steps=50, verbose=false, remeasure=remeasure) # warm up
-        suite[bstr][repr(n)] = BenchmarkGroup([repr(n)])
         KA_backend = KernelAbstractions.get_backend(sim.flow.p)
+        warmup!(sim, ft, remeasure, KA_backend) # JIT + settle device clocks
+        suite[bstr][repr(n)] = BenchmarkGroup([repr(n)])
         @add_benchmark sim_step!($sim, $typemax($ft); max_steps=$s, verbose=false, remeasure=$remeasure) $KA_backend suite[bstr][repr(n)] "sim_step!"
     end
 end

--- a/util.jl
+++ b/util.jl
@@ -30,11 +30,7 @@ macro add_benchmark(args...)
     end |> esc
 end
 
-# Warm up until BOTH a step count and a wall-clock budget are met, so small fast cases
-# drive the device to steady (boost) clocks before timing. A short fixed-step warm-up
-# leaves a freshly precompiled GPU at idle clocks, giving the first version in a session a
-# cold-start penalty (the spurious ~3x GPU swings in the v7-v8 data). `min_steps` dominates
-# for large cases, so only the clock-sensitive small ones pay extra.
+# Warm up until step count and a wall-clock budget are met and force backend sync
 function warmup!(sim, ft, remeasure, KA_backend; min_steps=50, seconds=2.0)
     steps = 0; t0 = time()
     while steps < min_steps || (time() - t0) < seconds
@@ -42,7 +38,6 @@ function warmup!(sim, ft, remeasure, KA_backend; min_steps=50, seconds=2.0)
         KernelAbstractions.synchronize(KA_backend)
         steps += 10
     end
-    return steps
 end
 
 function add_to_suite!(suite, sim_function; p=(3,4,5), s=100, ft=Float32, backend=Array, bstr="CPU", remeasure=false)


### PR DESCRIPTION
Two small, constraint-respecting hardening changes (no version interleaving, no extra samples), motivated by the v7→v8 sweeps where benchmark noise dwarfed the real differences between versions.

### `util.jl` — sustained warm-up
The fixed 50-step warm-up is too short on small cases, so a freshly checked-out/precompiled GPU is still at **idle clocks** when timing starts. Because `benchmark.sh` runs versions back-to-back, the *first* version measured in a session eats a cold-start penalty — the source of the spurious −22%/−65% GPU "speedups" seen in the data (a cold GPU read ~3× slow vs the same code warm). The new `warmup!()` loops until **both** a step count (≥50) **and** a wall-clock budget (≥2 s) are met, synchronizing each iteration so the device reaches steady (boost) clocks. Large/slow cases are unaffected because `min_steps` already exceeds the budget; only the small, clock-sensitive cases pay extra. No interleaving, no added samples.

### `compare.jl` — `Noise [%]` column
Adds a `Noise` column = the within-run min→max sample spread, computed from the *existing* 5 samples (no extra runs). It lets a reader separate signal from noise at a glance: any `|Δ|` below `Noise` is measurement scatter. For example, in the v7→v8 data `tgv CPUx01` shows `Δ=−10.2%` with `Noise=19.5%` — clearly noise. Also documents that `Alloc` is only meaningful on the SIMD backend (CPUx01); KA backends (multi-thread CPU, GPU) report kernel-launch bookkeeping, not algorithmic allocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)